### PR TITLE
Add simple Tkinter form for service orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sistema sencillo para registrar órdenes de servicio en un taller de reparación
 python ordenes_servicio.py
 ```
 
-El script crea la base de datos `ordenes.db`, registra un ejemplo de orden y genera un archivo de texto con los datos de la orden.
+Al ejecutar el script se abre una pequeña ventana en la que se pueden ingresar los datos del cliente y del equipo. La información se almacena en la base de datos `ordenes.db` y se genera un archivo de texto con los detalles de la orden.
 
 ## Estructura de la base de datos
 - **clientes**: datos del cliente (nombre, dirección, celular, DNI).


### PR DESCRIPTION
## Summary
- add a minimal Tkinter GUI for entering client and equipment data
- document the new window-based workflow in README

## Testing
- `python -m py_compile ordenes_servicio.py`
- `python - <<'PY' from ordenes_servicio import get_connection, init_db, add_cliente, add_orden, generar_hoja_txt; from pathlib import Path; with get_connection() as conn: init_db(conn); cid = add_cliente(conn, 'Test', '', '000', '123'); num = add_orden(conn, cid, 'Laptop', 'Dell', 'XPS', 'SN', 'Falla', '', ''); generar_hoja_txt(conn, num, Path(f'orden_{num:05d}.txt')); print('ok', num); PY`

------
https://chatgpt.com/codex/tasks/task_e_6896c8accd108324a7e146f34ddbfb79