### PR TITLE
Generar hoja PDF y registrar fecha de clientes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ Sistema sencillo para registrar órdenes de servicio en un taller de reparación
 python ordenes_servicio.py
 ```
 
-Al ejecutar el script se abre una pequeña ventana en la que se pueden ingresar los datos del cliente y del equipo. La información se almacena en la base de datos `ordenes.db` y se genera un archivo de texto con los detalles de la orden.
+Requiere la biblioteca [`fpdf2`](https://pypi.org/project/fpdf2/) para generar el PDF.
+
+Al ejecutar el script se abre una pequeña ventana en la que se pueden ingresar los datos del cliente y del equipo. La información se almacena en la base de datos `ordenes.db` y se genera un archivo PDF listo para imprimir con los detalles de la orden.
 
 ## Estructura de la base de datos
-- **clientes**: datos del cliente (nombre, dirección, celular, DNI).
-- **ordenes_servicio**: información del equipo, descripción de la falla, diagnóstico y solución.
+- **clientes**: datos del cliente (nombre, dirección, celular, DNI, fecha de registro).
+- **ordenes_servicio**: información del equipo, descripción de la falla, diagnóstico, solución y fecha de ingreso.
 
 Cada orden recibe un número secuencial que se almacena junto con la fecha de ingreso.


### PR DESCRIPTION
## Summary
- Añade registro de fecha y hora para clientes
- Genera hoja de orden en PDF lista para imprimir

## Testing
- `python -m py_compile ordenes_servicio.py`


------
https://chatgpt.com/codex/tasks/task_e_6896ca7772b08324a7eef3b3285462a0